### PR TITLE
not put below expected altitudes on aircrafts cruise altitudes

### DIFF
--- a/src/flight.py
+++ b/src/flight.py
@@ -21,10 +21,12 @@ def arrival(callsign, departure, destination, rwy):
   random_altitude = choice(AIRPORT_SETTINGS[destination]['GET_FL'][fp_direction][level])
   flight_plan = ':*A:I:B738:364:'+departure+':0000:0000:'+random_altitude+':'+destination+':00:00:0:0::/v/:'
   
+  #Preve planos de voo inferiores à altitude de cruzeiro para LOW_LEVEL FP's	
   if (random_altitude < expected_alt and level == 'LOW_LEVEL'):
 	  expected_alt = random_altitude
   #Prever a mesma situação para HIGH_LEVEL	  
-  #if (random_altitude < expected_alt and level == 'HIGH_LEVEL'):
+  if (random_altitude < expected_alt and level == 'HIGH_LEVEL'):
+	  random_altitude = max(AIRPORT_SETTINGS[destination]['GET_FL'][fp_direction][level])
 	   
 	
   return position_coords, '''

--- a/src/flight.py
+++ b/src/flight.py
@@ -20,7 +20,13 @@ def arrival(callsign, departure, destination, rwy):
   route, position_coords, expected_alt = AIRPORT_SETTINGS[destination]['ARRIVAL_ROUTES'][rwy][position]
   random_altitude = choice(AIRPORT_SETTINGS[destination]['GET_FL'][fp_direction][level])
   flight_plan = ':*A:I:B738:364:'+departure+':0000:0000:'+random_altitude+':'+destination+':00:00:0:0::/v/:'
-
+  
+  if (random_altitude < expected_alt and level == 'LOW_LEVEL'):
+	  expected_alt = random_altitude
+  #Prever a mesma situação para HIGH_LEVEL	  
+  #if (random_altitude < expected_alt and level == 'HIGH_LEVEL'):
+	   
+	
   return position_coords, '''
 @N:{callsign}:0000:1:{position_coords}:{random_altitude}:0:50:0:0
 $FP{callsign}{flight_plan}


### PR DESCRIPTION
- A ideia aqui é que uma aeronave que tenha por exemplo previsto EXONA:29000 mas navegue a com um plano de voo de FL230 não comece a subir para 29000 quando deve manter os 23000.

- Já consegui colocar a funcionar para Niveis de voo baixos (LOW_LEVEL FP's)
